### PR TITLE
Proposing a case study on transparency

### DIFF
--- a/open_org_workbook_toc.md
+++ b/open_org_workbook_toc.md
@@ -15,7 +15,7 @@
 
 - Introduction: What is transparency and why is it important?—Phil Foster
 - Case study: Buffer (topic TBD)—Hailley Griffis
-- Case study: 
+- Case study: Culture First, Tools Last (How Autodesk Uses Slack to Increase Transparency)-Guy Martin
 - Exercise: 
 - Exercise: 
 


### PR DESCRIPTION
I've given numerous talks which include the phrase 'Culture First, Tools Last.'  This comes out of my direct experience working for tools vendors and seeing how tools seem to always be the first thing people think about to solve collaboration or transparency problems, instead of looking at existing culture and processes for hints to what might be successful.

I'd like to propose a case-study topic for the book which shows how we turned the tables on that with our Slack installation at Autodesk. The tool itself isn't important - it could have been IRC, HipChat, or several others.  What is important is how we looked at our culture, and determined what needed to change to increase transparency.  We then looked around to see where natural community was forming to accomplish this - Slack was being adopted virally, but in divisional silos.

We put together a plan which rolled Slack out as a central instance, managed by a group of community volunteers and with a 'Default to Open' paradigm that has significantly increased transparency at a company that previously talked sparingly between product teams.